### PR TITLE
1.16.21 | Added JWT Auth to ignore current password if its the admin …

### DIFF
--- a/src/controllers/register.controller.ts
+++ b/src/controllers/register.controller.ts
@@ -46,8 +46,6 @@ export const registerUser: RequestHandler = async (req, res) => {
         return
     }
 
-    const passwordRegex = /^(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{5,16}$/;
-
     const passwordRequirements = [
         { regex: /[A-Z]/, message: 'Password must contain at least 1 uppercase letter.' },
         { regex: /\d/, message: 'Password must contain at least 1 number.' },


### PR DESCRIPTION
- JWT auth now recognises if the user is admin or not and if it is, then it ignores the current password check required when password is to be changed. This way if user forgot their password and even admin doesn't know the password as it is hashed then admin can just enter the new password and it'll change.
- Added sign up password regex check into the edit password regex in the profile menu.